### PR TITLE
compact db - support for password protected db, allow space within datab...

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -2727,7 +2727,7 @@ def win_connect_mdb(mdb_path):
     
     
     
-def win_compact_mdb(mdb_path, compacted_mdb_path, sort_order = "General\0\0"):
+def win_compact_mdb(mdb_path, compacted_mdb_path=None, sort_order = "General\0", password=None):
     if sys.platform not in ('win32','cli'):
         raise Exception('This function is available for use in Windows only.')
     
@@ -2741,11 +2741,19 @@ def win_compact_mdb(mdb_path, compacted_mdb_path, sort_order = "General\0\0"):
     #COMPACT_DB=<source path> <destination path> <sort order>
     ctypes.windll.ODBCCP32.SQLConfigDataSource.argtypes = [ctypes.c_void_p,ctypes.c_ushort,ctypes.c_char_p,ctypes.c_char_p]
     #driver_name = "Microsoft Access Driver (*.mdb)"
+    
+    if not compacted_mdb_path:
+        compacted_mdb_path = mdb_path
+    
+    pass_config = ""
+    if password:
+        pass_config = "PWD=" + password
+    
     if py_v3:
-        c_Path = bytes("COMPACT_DB=" + mdb_path + " " + compacted_mdb_path + " " + sort_order,'mbcs')
+        c_Path = bytes("COMPACT_DB=\"" + mdb_path + "\" \"" + compacted_mdb_path + "\" " + sort_order + pass_config,'mbcs')
         #driver_name = bytes(driver_name,'mbcs')
     else:
-        c_Path = "COMPACT_DB=" + mdb_path + " " + compacted_mdb_path + " " + sort_order
+        c_Path = "COMPACT_DB=\"" + mdb_path + "\" \"" + compacted_mdb_path + "\" " + sort_order + pass_config
 
     ODBC_ADD_SYS_DSN = 1
     ret = ctypes.windll.ODBCCP32.SQLConfigDataSource(None,ODBC_ADD_SYS_DSN,driver_name, c_Path)


### PR DESCRIPTION
For **win_compact_mdb** function, I have added following supports:
* support for password protected database
* support for spaces within database paths
* optional **compacted_mdb_path** argument
  * if **compacted_mdb_path** is not provided, same database (**mdb_path**) will be considered for output
