### PR TITLE
Fixing compatibility with linux freetds, fixing Exception TypeError '…

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -1914,7 +1914,9 @@ class Cursor:
                     elif ret == SQL_SUCCESS_WITH_INFO:
                         # Means the data is only partial
                         if target_type == SQL_C_BINARY:
-                            raw_data_parts.append(alloc_buffer.raw)
+                            raw_data_parts.append(alloc_buffer.raw[:used_buf_len.value])
+                        elif target_type == SQL_C_WCHAR:
+                            raw_data_parts.append(from_buffer_u(alloc_buffer))
                         else:
                             raw_data_parts.append(alloc_buffer.value)  
          
@@ -1927,7 +1929,8 @@ class Cursor:
                 if raw_data_parts != []:
                     if py_v3:
                         if target_type != SQL_C_BINARY:
-                            raw_value = ''.join(raw_data_parts)
+                            data_parts = [x.decode("utf-8") if type(x) is bytes else x for x in raw_data_parts]
+                            raw_value = ''.join(data_parts)
                         else:
                             raw_value = BLANK_BYTE.join(raw_data_parts)
                     else:


### PR DESCRIPTION
This change request is in order to fix a bug when using pypyodbc on Linux and reading from columns with large text values. Actually, the code raise and exceptions TypeError with the text "expected str instance, bytes found"
The previous code works perfectly in windows, but the same code raised exception TYPEERROR on Linux when SQLGetData return SQL_SUCCESS_WITH_INFO because the column value has more than 1024 characters. 
My proposal fixed 2 errors:
1-Convert bytes to strings before joins results into a single value at line 1950
2-At line 1930 read value properly before add it to the raw_data_parts list
I tested the code I am proposing on Linux and Windows, on both works perfect with long string columns. I hope this help somebody else.