### PR TITLE
add to_dict method to default Row class

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -1048,10 +1048,14 @@ def TupleRow(cursor):
         
         def get(self, field):
             if not hasattr(self, 'field_dict'):
-                self.field_dict = {}
-                for i,item in enumerate(self):
-                    self.field_dict[self.cursor_description[i][0]] = item
+                self.field_dict = self.to_dict()
             return self.field_dict.get(field)
+
+        def to_dict(self):
+            return {
+                self.cursor_description[i][0]: item
+                for i, item in enumerate(self)
+            }
             
         def __getitem__(self, field):
             if isinstance(field, (unicode,str)):


### PR DESCRIPTION
hello 👋 !

This extracts the creation of `.field_dict` for the default `Row` class into a separate method.

Currently, if you want a row as a dict, you have to:

```python
for row in cursor.fetchall():
    row.get("")  # Empty call to get `field_dict` to populate
    my_dict = row.field_dict
```

This simplifies this use case to:

```python
for row in cursor.fetchall():
    my_dict = row.to_dict()
```