### PR TITLE
Fixes issue 70, where empty strings are returned as None

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -1906,7 +1906,7 @@ class Cursor:
                                         ctypes.memset(ctypes.addressof(alloc_buffer) + used_buf_len.value, 0, 1)
                                     value_list.append(buf_cvt_func(from_buffer_u(alloc_buffer)))
                                 elif alloc_buffer.value == '':
-                                    value_list.append(None)
+                                    value_list.append('')
                                 else:
                                     value_list.append(buf_cvt_func(alloc_buffer.value))
                             else:


### PR DESCRIPTION
When I made this change suggested by @braian87b in issue 70 my query against SQL Server of
`cur.execute('SELECT NULL AS "a", \'\' AS "b"')`
the `repr(cur.fetchall())` is
`[(None, u'')]`
which matches the behavior of pyodbc.
