### PR TITLE
Removed superfluous second setting of SQL_ATTR_ACCESS_MODE in connect()

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -2544,9 +2544,6 @@ class Connection:
             ret = ODBC_API.SQLSetConnectAttr(self.dbc_h, SQL_ATTR_ACCESS_MODE, SQL_MODE_READ_ONLY, SQL_IS_UINTEGER)
             check_success(self, ret)
         
-        ret = ODBC_API.SQLSetConnectAttr(self.dbc_h, SQL_ATTR_ACCESS_MODE, self.readonly and SQL_MODE_READ_ONLY or SQL_MODE_READ_WRITE, SQL_IS_UINTEGER)
-        check_success(self, ret)
-        
         self.unicode_results = unicode_results
         self.connected = 1
         self.update_db_special_info()


### PR DESCRIPTION
Removed the call to SQLSetConnectAttr that set SQL_ATTR_ACCESS_MODE every time connect() was called.  Kept the call that sets SQL_ATTR_ACCESS_MODE only when the user specifies a read-only connection.  My rationale for this choice is (1) that it is better practice not to explicitly set attributes that equate to default behaviour, because it plays better for our user if a (poorly designed) ODBC driver has not implemented the attribute, and (2) that this is how I believe pyodbc behaves with 'readonly'.

I think the same arguments would lead to only setting SQL_ATTR_AUTOCOMMIT if autocommit is false, but I don't have the nerve to make that change as well, or to search for other similar cases!