### PR TITLE
master

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -588,13 +588,13 @@ def dttm_cvt(x):
     if py_v3:
         x = x.decode('ascii')
     if x == '': return None
-    else: return datetime.datetime(int(x[0:4]),int(x[5:7]),int(x[8:10]),int(x[10:13]),int(x[14:16]),int(x[17:19]),int(x[20:26].ljust(6,'0')))
+    else: return datetime.datetime(int(x[0:4]),int(x[5:7]),int(x[8:10]),int(x[10:13]),int(x[14:16]),int(x[17:19]),int(x[20:26].ljust(6,'0')[:6]))
 
 def tm_cvt(x):
     if py_v3:
         x = x.decode('ascii')
     if x == '': return None
-    else: return datetime.time(int(x[0:2]),int(x[3:5]),int(x[6:8]),int(x[9:].ljust(6,'0')))
+    else: return datetime.time(int(x[0:2]),int(x[3:5]),int(x[6:8]),int(x[9:].ljust(6,'0')[:6]))
 
 def dt_cvt(x):
     if py_v3:


### PR DESCRIPTION
Datetime and time conversions pad microseconds to 6 characters. Functions don't limit length to maximum 6 characters, causing errors.